### PR TITLE
Global support (with the language set to simplified Chinese)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ pydirectinput-rgx
 pywin32
 pyyaml
 onnxruntime-gpu
+setuptools

--- a/utils/init.py
+++ b/utils/init.py
@@ -63,6 +63,8 @@ OffsetX = 0
 OffsetY = 0
 Hwnd = win32gui.FindWindow("UnityWndClass", "绝区零")
 if Hwnd == 0:
+    Hwnd = win32gui.FindWindow("UnityWndClass", "ZenlessZoneZero")
+if Hwnd == 0:
     logger.error("未找到游戏窗口")
 else:
     # 将游戏窗口移动到屏幕左上角


### PR DESCRIPTION
setuptools is required for some function in the task file, my windows is newly set up for Python so that gave me an error message before I installed setuptools. I'm also playing on the US server so the progress has the name "ZenlessZoneZero" instead of "绝区零", just adding another check so it should support global version, at least with the game language set to simplified Chinese.