### PR TITLE
Add windows path compatibility.

### DIFF
--- a/utils/detect/current.py
+++ b/utils/detect/current.py
@@ -16,7 +16,7 @@ from .utils import LetterBox
 model_path = RootPath / "download" / "current.onnx"
 
 logger.info(f"使用 {','.join(Provider)} 运行当前位置识别模型")
-model = InferenceSession(model_path, providers=Provider)
+model = InferenceSession(str(model_path), providers=Provider)
 input_name = model.get_inputs()[0].name
 label_name = model.get_outputs()[0].name
 

--- a/utils/map/components.py
+++ b/utils/map/components.py
@@ -20,13 +20,13 @@ DownloadPath = RootPath / "download"  # 下载路径
 
 # components_model = InferenceSession(DownloadPath / "components.onnx")
 components_model = InferenceSession(
-    DownloadPath / "components_level.onnx", providers=Provider
+    str(DownloadPath / "components_level.onnx"), providers=Provider
 )
 components_input_name = components_model.get_inputs()[0].name
 components_output_name = components_model.get_outputs()[0].name
 
 television_model = InferenceSession(
-    DownloadPath / "television.onnx", providers=Provider
+    str(DownloadPath / "television.onnx"), providers=Provider
 )
 television_input_name = television_model.get_inputs()[0].name
 television_output_name = television_model.get_outputs()[0].name


### PR DESCRIPTION
This pr is to address the following path inconsistency when running on Windows.
```
2024-07-19 22:12:29.095 | INFO     | utils.detect.current:<module>:18 - 使用 CPUExecutionProvider 运行当前位置识别模型
Traceback (most recent call last):
  File "D:\AutoZenlessZoneZero\main.py", line 29, in <module>
    from utils.task import task
  File "D:\AutoZenlessZoneZero\utils\__init__.py", line 21, in <module>
    from .map import get_map_info, auto_find_way
  File "D:\AutoZenlessZoneZero\utils\map\__init__.py", line 8, in <module>
    from .components import get_map_info
  File "D:\AutoZenlessZoneZero\utils\map\components.py", line 15, in <module>
    from ..detect import Model, find_current
  File "D:\AutoZenlessZoneZero\utils\detect\__init__.py", line 9, in <module>
    from .current import find_current
  File "D:\AutoZenlessZoneZero\utils\detect\current.py", line 19, in <module>
    model = InferenceSession(model_path, providers=Provider)
  File "C:\Users\meili\.conda\envs\alas\lib\site-packages\onnxruntime\capi\onnxruntime_inference_collection.py", line 349, in __init__
    raise TypeError("Unable to load from type '{0}'".format(type(path_or_bytes)))
TypeError: Unable to load from type '<class 'pathlib.WindowsPath'>'
```