### PR TITLE
防止.git敏感信息泄露

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,6 +49,8 @@ jobs:
         # 需要start.exe下载地址
         Set-Content "Start.bat" "chcp 65001 & cd /d %~dp0 & .\py310\python.exe main.py & pause"
         Copy-Item config.example.yaml config.yaml
+        # 防止敏感信息泄露
+        Remove-Item .git\ -Force -Recurse
         7z a -tzip zzzAuto-Onekey.zip ..
     
     - name: Release


### PR DESCRIPTION
太抱歉了.git是个隐藏文件夹没检查出来，存在github令牌泄露风险，已删除。具体报告见下
https://www.bleepingcomputer.com/news/security/github-actions-artifacts-found-leaking-auth-tokens-in-popular-projects/