### PR TITLE
Update incident.py

### DIFF
--- a/handle/incident.py
+++ b/handle/incident.py
@@ -8,7 +8,7 @@ import time
 from typing import Dict
 
 import numpy as np
-from numpy.distutils.command.config import config
+# from numpy.distutils.command.config import config
 
 from schema import Position, info
 from utils import control, screenshot, logger, RootPath


### PR DESCRIPTION
solve the import error "numpy.distutils"


it may cause the ModuleNotFoundError: No module named 'numpy.distutils'
however, there is no use of the "config" in the rest of our file